### PR TITLE
Update dwi_pipe_params.cfg

### DIFF
--- a/params/hcp/dwi_pipe_params.cfg
+++ b/params/hcp/dwi_pipe_params.cfg
@@ -44,8 +44,8 @@ bhigh: 2000
 
 
 ## [WMA800] ##
-slicer_exec: /software/rocky9/Slicer-5.6.1-linux-amd64/Slicer
-FiberTractMeasurements: /software/rocky9/Slicer-5.6.1-linux-amd64/slicer.org/Extensions-32438/SlicerDMRI/lib/Slicer-5.6/cli-modules/FiberTractMeasurements
+slicer_exec: /software/rocky9/Slicer-5.8.1-linux-amd64/Slicer
+FiberTractMeasurements: /software/rocky9/Slicer-5.8.1-linux-amd64/slicer.org/Extensions-33241/SlicerDMRI/lib/Slicer-5.8/cli-modules/FiberTractMeasurements
 atlas: /software/rocky9/ORG-Atlases-1.2
 wma_nproc: 4
 xvfb: 1


### PR DESCRIPTION
Needed to update the Slicer path to the new Slicer 8.1. Discovered the issue when testing the HCP pipelines hcp_pnl_topup.lsf script with Wma800 as the task.